### PR TITLE
Fix Capistrano warning

### DIFF
--- a/lib/capistrano/tasks/releases_notification.rake
+++ b/lib/capistrano/tasks/releases_notification.rake
@@ -15,6 +15,7 @@ namespace :release do
 
   desc "notify release to slack"
   task :notify do
+    Rake::Task['github:releases:authentication'].reenable
     invoke 'github:releases:authentication'
 
     fetch(:release_notify_channel).each do |channel|


### PR DESCRIPTION
Hi.

Capistrano(>= 3.6.0) outputs warning like below when run the `release:notify` task in `deploy` task.

```
Skipping task `github:releases:authentication'.
Capistrano tasks may only be invoked once. Since task `github:releases:authentication' was previously invoked, invoke("github:releases:authentication") at /path/to/project/vendor/bundle/ruby/2.3.0/gems/capistrano-releases-notification-0.1.1/lib/capistrano/tasks/releases_notification.rake:18 will be skipped.
If you really meant to run this task again, first call Rake::Task["github:releases:authentication"].reenable
THIS BEHAVIOR MAY CHANGE IN A FUTURE VERSION OF CAPISTRANO. Please join the conversation here if this affects you.
https://github.com/capistrano/capistrano/issues/1686
```

This patch fixes the warning.

refs https://github.com/capistrano/capistrano/pull/1730